### PR TITLE
fix: preserve time in minutes for workflow simulation

### DIFF
--- a/Form for NAT.pa.yaml
+++ b/Form for NAT.pa.yaml
@@ -5372,7 +5372,11 @@ Screens:
                                           )
                                       ).field_5 / 60 / 24) + (HoursArrival.Selected.Value / 24 + MinutesArrival.Selected.Value / 1440) + (5 / 60 / 24)
                                   )),
-                                  'Time in Minutes 1': 0,
+                                'Time in Minutes 1': If(
+                                    IsBlank(TimeInMinutes.Text),
+                                    0,
+                                    Value(TimeInMinutes.Text)
+                                ),
                                   '# Pools': If(
                                       IsBlank(NumPoolsXT.Text),
                                       0,

--- a/Src/Form for NAT.pa.yaml
+++ b/Src/Form for NAT.pa.yaml
@@ -5372,7 +5372,11 @@ Screens:
                                           )
                                       ).field_5 / 60 / 24) + (HoursArrival.Selected.Value / 24 + MinutesArrival.Selected.Value / 1440) + (5 / 60 / 24)
                                   )),
-                                  'Time in Minutes 1': 0,
+                                'Time in Minutes 1': If(
+                                    IsBlank(TimeInMinutes.Text),
+                                    0,
+                                    Value(TimeInMinutes.Text)
+                                ),
                                   '# Pools': If(
                                       IsBlank(NumPoolsXT.Text),
                                       0,


### PR DESCRIPTION
## Summary
- ensure workflow simulation updates store actual `Time in Minutes 1` instead of zero so downstream calculations like `Time to release pool runs` work

## Testing
- `pac test run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892415928148326ab39f407fabce4ba