### PR TITLE
feat: add samples already pooled toggle

### DIFF
--- a/Form for NAT.pa.yaml
+++ b/Form for NAT.pa.yaml
@@ -5372,7 +5372,11 @@ Screens:
                                           )
                                       ).field_5 / 60 / 24) + (HoursArrival.Selected.Value / 24 + MinutesArrival.Selected.Value / 1440) + (5 / 60 / 24)
                                   )),
-                                  'Time in Minutes 1': 0,
+                                'Time in Minutes 1': If(
+                                    IsBlank(TimeInMinutes.Text),
+                                    0,
+                                    Value(TimeInMinutes.Text)
+                                ),
                                   '# Pools': If(
                                       IsBlank(NumPoolsXT.Text),
                                       0,
@@ -8601,6 +8605,94 @@ Screens:
                         Width: =DataCardValue31.Width
                         X: =DataCardValue31.X
                         Y: =DataCardValue31.Y + DataCardValue31.Height
+            - SamplesalreadyPooled_DataCard1:
+                Control: TypedDataCard@1.0.7
+                Variant: ClassicToggleEdit
+                Properties:
+                  BorderColor: =RGBA(0, 18, 107, 1)
+                  DataField: ="SamplesalreadyPooled"
+                  Default: =If(copiardataassayanterior,Itemultiassay.'Samples already Pooled?', ThisItem.'Samples already Pooled?')
+                  DisplayName: =DataSourceInfo([@'DX-SALES NAT Workflow Tool | List Assays'],DataSourceInfo.DisplayName,'Samples already Pooled?')
+                  Required: =false
+                  Update: =DataCardValueSAP.Value
+                  Width: =546
+                  X: =0
+                  Y: =21
+                Children:
+                  - DataCardKeySAP:
+                      Control: Label@2.5.1
+                      MetadataKey: FieldName
+                      Properties:
+                        AutoHeight: =true
+                        BorderColor: =RGBA(0, 0, 0, 1)
+                        Color: =RGBA(0, 18, 107, 1)
+                        Font: =Font.'Open Sans'
+                        Height: =34
+                        Text: =Parent.DisplayName
+                        Width: =Parent.Width - 60
+                        Wrap: =false
+                        X: =30
+                        Y: =10
+                  - DataCardValueSAP:
+                      Control: Classic/Toggle@2.1.0
+                      MetadataKey: FieldValue
+                      Properties:
+                        AccessibleLabel: =" "
+                        BorderColor: =If(IsBlank(Parent.Error), Parent.BorderColor, Color.Red)
+                        Default: =Parent.Default
+                        DisplayMode: =Parent.DisplayMode
+                        FalseText: ="No"
+                        FocusedBorderThickness: =0
+                        Font: =Font.'Open Sans'
+                        Tooltip: =Parent.DisplayName
+                        TrueFill: =RGBA(9, 33, 98, 1)//RGBA(56, 96, 178, 1)
+                        TrueText: ="Yes"
+                        X: =500
+                        Y: =12
+                  - ErrorMessageSAP:
+                      Control: Label@2.5.1
+                      MetadataKey: ErrorMessage
+                      Properties:
+                        AutoHeight: =true
+                        BorderColor: =RGBA(0, 0, 0, 1)
+                        Color: =RGBA(168, 0, 0, 1)
+                        Font: =Font.'Open Sans'
+                        FontWeight: =FontWeight.Semibold
+                        Height: =10
+                        Live: =Live.Assertive
+                        PaddingBottom: =0
+                        PaddingLeft: =0
+                        PaddingRight: =0
+                        PaddingTop: =0
+                        Size: =14
+                        Text: =If(IsBlank(Parent.Error),Parent.Error,"This field is required")
+                        Visible: =Parent.DisplayMode=DisplayMode.Edit
+                        Width: =Parent.Width - 60
+                        X: =30
+                        Y: =DataCardValueSAP.Y + DataCardValueSAP.Height
+                  - StarVisibleSAP:
+                      Control: Label@2.5.1
+                      MetadataKey: FieldRequired
+                      Properties:
+                        Align: =Align.Center
+                        BorderColor: =RGBA(0, 0, 0, 1)
+                        Color: =RGBA(0, 18, 107, 1)
+                        Font: =Font.'Open Sans'
+                        Height: =DataCardKeySAP.Height
+                        Text: ="*"
+                        Visible: =And(Parent.Required, Parent.DisplayMode=DisplayMode.Edit)
+                        Width: =30
+                        Wrap: =false
+                        Y: =DataCardKeySAP.Y
+                  - Rectangle3_SAP:
+                      Control: Rectangle@2.3.0
+                      Properties:
+                        BorderColor: =RGBA(0, 18, 107, 1)
+                        Fill: =RGBA(200,200,200,1)//RGBA(56, 96, 178, 1)
+                        Height: =2
+                        Width: =DataCardValueSAP.Width
+                        X: =DataCardValueSAP.X
+                        Y: =DataCardValueSAP.Y + DataCardValueSAP.Height
             - PoolTypeText_DataCard1:
                 Control: TypedDataCard@1.0.7
                 Variant: ClassicTextualEdit

--- a/References/DataSources.json
+++ b/References/DataSources.json
@@ -279,6 +279,7 @@
         "{HasAttachments}": "Has attachments",
         "{VersionNumber}": "Version number",
         "GrifolsPoolerInstrument": "Grifols Pooler Instrument",
+        "SamplesalreadyPooled": "Samples already Pooled?",
         "Set_x0020_Size": "Set Size",
         "{Identifier}": "Identifier",
         "FinalPoolsizeperassay_Num": "Final Pool size per assay Num",

--- a/Src/Form for NAT.pa.yaml
+++ b/Src/Form for NAT.pa.yaml
@@ -5372,7 +5372,11 @@ Screens:
                                           )
                                       ).field_5 / 60 / 24) + (HoursArrival.Selected.Value / 24 + MinutesArrival.Selected.Value / 1440) + (5 / 60 / 24)
                                   )),
-                                  'Time in Minutes 1': 0,
+                                'Time in Minutes 1': If(
+                                    IsBlank(TimeInMinutes.Text),
+                                    0,
+                                    Value(TimeInMinutes.Text)
+                                ),
                                   '# Pools': If(
                                       IsBlank(NumPoolsXT.Text),
                                       0,
@@ -8601,6 +8605,94 @@ Screens:
                         Width: =DataCardValue31.Width
                         X: =DataCardValue31.X
                         Y: =DataCardValue31.Y + DataCardValue31.Height
+            - SamplesalreadyPooled_DataCard1:
+                Control: TypedDataCard@1.0.7
+                Variant: ClassicToggleEdit
+                Properties:
+                  BorderColor: =RGBA(0, 18, 107, 1)
+                  DataField: ="SamplesalreadyPooled"
+                  Default: =If(copiardataassayanterior,Itemultiassay.'Samples already Pooled?', ThisItem.'Samples already Pooled?')
+                  DisplayName: =DataSourceInfo([@'DX-SALES NAT Workflow Tool | List Assays'],DataSourceInfo.DisplayName,'Samples already Pooled?')
+                  Required: =false
+                  Update: =DataCardValueSAP.Value
+                  Width: =546
+                  X: =0
+                  Y: =21
+                Children:
+                  - DataCardKeySAP:
+                      Control: Label@2.5.1
+                      MetadataKey: FieldName
+                      Properties:
+                        AutoHeight: =true
+                        BorderColor: =RGBA(0, 0, 0, 1)
+                        Color: =RGBA(0, 18, 107, 1)
+                        Font: =Font.'Open Sans'
+                        Height: =34
+                        Text: =Parent.DisplayName
+                        Width: =Parent.Width - 60
+                        Wrap: =false
+                        X: =30
+                        Y: =10
+                  - DataCardValueSAP:
+                      Control: Classic/Toggle@2.1.0
+                      MetadataKey: FieldValue
+                      Properties:
+                        AccessibleLabel: =" "
+                        BorderColor: =If(IsBlank(Parent.Error), Parent.BorderColor, Color.Red)
+                        Default: =Parent.Default
+                        DisplayMode: =Parent.DisplayMode
+                        FalseText: ="No"
+                        FocusedBorderThickness: =0
+                        Font: =Font.'Open Sans'
+                        Tooltip: =Parent.DisplayName
+                        TrueFill: =RGBA(9, 33, 98, 1)//RGBA(56, 96, 178, 1)
+                        TrueText: ="Yes"
+                        X: =500
+                        Y: =12
+                  - ErrorMessageSAP:
+                      Control: Label@2.5.1
+                      MetadataKey: ErrorMessage
+                      Properties:
+                        AutoHeight: =true
+                        BorderColor: =RGBA(0, 0, 0, 1)
+                        Color: =RGBA(168, 0, 0, 1)
+                        Font: =Font.'Open Sans'
+                        FontWeight: =FontWeight.Semibold
+                        Height: =10
+                        Live: =Live.Assertive
+                        PaddingBottom: =0
+                        PaddingLeft: =0
+                        PaddingRight: =0
+                        PaddingTop: =0
+                        Size: =14
+                        Text: =If(IsBlank(Parent.Error),Parent.Error,"This field is required")
+                        Visible: =Parent.DisplayMode=DisplayMode.Edit
+                        Width: =Parent.Width - 60
+                        X: =30
+                        Y: =DataCardValueSAP.Y + DataCardValueSAP.Height
+                  - StarVisibleSAP:
+                      Control: Label@2.5.1
+                      MetadataKey: FieldRequired
+                      Properties:
+                        Align: =Align.Center
+                        BorderColor: =RGBA(0, 0, 0, 1)
+                        Color: =RGBA(0, 18, 107, 1)
+                        Font: =Font.'Open Sans'
+                        Height: =DataCardKeySAP.Height
+                        Text: ="*"
+                        Visible: =And(Parent.Required, Parent.DisplayMode=DisplayMode.Edit)
+                        Width: =30
+                        Wrap: =false
+                        Y: =DataCardKeySAP.Y
+                  - Rectangle3_SAP:
+                      Control: Rectangle@2.3.0
+                      Properties:
+                        BorderColor: =RGBA(0, 18, 107, 1)
+                        Fill: =RGBA(200,200,200,1)//RGBA(56, 96, 178, 1)
+                        Height: =2
+                        Width: =DataCardValueSAP.Width
+                        X: =DataCardValueSAP.X
+                        Y: =DataCardValueSAP.Y + DataCardValueSAP.Height
             - PoolTypeText_DataCard1:
                 Control: TypedDataCard@1.0.7
                 Variant: ClassicTextualEdit


### PR DESCRIPTION
## Summary
- ensure workflow simulation updates store actual `Time in Minutes 1` instead of zero so downstream calculations like `Time to release pool runs` work
- add `Samples already Pooled?` yes/no toggle after `Pool Type` to prevent counting samples twice

## Testing
- `pac test run` *(fails: ReferenceError: primordials is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6892415928148326ab39f407fabce4ba